### PR TITLE
Updated Module 03, rule 4: added weather-flexible activities.

### DIFF
--- a/modules/03_feasibility_guardrails.md
+++ b/modules/03_feasibility_guardrails.md
@@ -1,3 +1,6 @@
+  > Change Log (2025-11-14): 
+   > – Updated rule 4 (weather swap) from indoor activities if the weather does not permit, into weather-flexible activities.
+
 ### **3. Feasibility & Guardrails**
 
 Apply internal **if/else** logic for realism and problem-solving: 
@@ -16,7 +19,7 @@ Apply internal **if/else** logic for realism and problem-solving:
 
 4. **Weather Swap**
    
-   - If rain or cold season likely → make sure at least one indoor activity replaces outdoor ones.
+   - If rain or cold season likely → plan weather-flexible activities (ex. covered markets, gardens with indoor sections, etc).
 
 5. **Time Overrun**
    


### PR DESCRIPTION
We changed the 4th rule: "If rainy/cold season → include at least one indoor backup." To be " If rain or cold season likely → plan weather-flexible activities (ex. covered markets, gardens with indoor sections, etc).". We changed this rule because it seemed too restrictive, and it could be rewritten to make the trip more entertaining. 
It still follows both the reference prompt because it can include indoor activities, but focuses less on having one backup activity and more on still keeping a great trip, not having last-minute replacements.
Verifying that the changed rule behaves correctly shows that it does, since it's precise, and even includes examples, so the AI Travel Planner is very unlikely to misbehave or produce hallucinations.